### PR TITLE
fakelib* `SONAME` fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,12 +92,12 @@ elseif(WI4MPI_COMPILER MATCHES ARMCLANG)
     set(FC "armflang")
 endif()
 
-#Define the compiling option according to the choosen realease
-if(WI4MPI_REALEASE MATCHES DEBUG)
+#Define the compiling option according to the choosen release
+if(WI4MPI_RELEASE MATCHES DEBUG)
    set(WI4MPI_FLAGS ${CMAKE_C_FLAGS_DEBUG})
-elseif(WI4MPI_REALEASE MATCHES RELEASE)
+elseif(WI4MPI_RELEASE MATCHES RELEASE)
    set(WI4MPI_FLAGS ${CMAKE_C_FLAGS_RELEASE})
-elseif(WI4MPI_REALEASE MATCHES GCC_JIT)
+elseif(WI4MPI_RELEASE MATCHES GCC_JIT)
      set(WI4MPI_FLAGS ${CMAKE_C_FLAGS_GCC_JIT})
 else()
    set(WI4MPI_FLAGS ${CMAKE_C_FLAGS_NORMAL})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -422,25 +422,28 @@ add_library(wi4mpi_MPICH_OMPI SHARED ${SOURCE_WI4MPI_PRELOAD})
 add_library(wi4mpi_MPICH_INTEL SHARED ${SOURCE_WI4MPI_PRELOAD})
 #Empty libraries
 set(LIST_FAKEINTEL mpi mpifort mpigf mpi_mt)
-set(LIST_FAKEINTEL_SOEXT so.4 so.5 so.12)
+set(LIST_FAKEINTEL_MAJOR 4 5 12)
 set(LIST_FAKEOMPI mpi mpi_mpifh mpi_usempif08 mpi_usempi_ignore_tkr)
-set(LIST_FAKEOMPI_SOEXT so.1 so.20 so.40)
+set(LIST_FAKEOMPI_MAJOR 1 20 40)
 set(LIST_FAKECXX mpicxx mpi_cxx)
-set(LIST_FAKECXX_SOEXT ${LIST_FAKEINTEL_SOEXT} ${LIST_FAKEOMPI_SOEXT})
+set(LIST_FAKECXX_MAJOR ${LIST_FAKEINTEL_MAJOR} ${LIST_FAKEOMPI_MAJOR})
 foreach(LIB ${LIST_FAKECXX})
-    foreach(SOEXT ${LIST_FAKECXX_SOEXT})
-        add_library(${LIB}.${SOEXT} SHARED ${SOURCE_WI4MPI_EMPTY})
-    endforeach(SOEXT)
+    foreach(MAJOR ${LIST_FAKECXX_MAJOR})
+        add_library(${LIB}${MAJOR} SHARED ${SOURCE_WI4MPI_EMPTY})
+        set_target_properties(${LIB}${MAJOR} PROPERTIES OUTPUT_NAME ${LIB} SOVERSION ${MAJOR})
+    endforeach(MAJOR)
 endforeach(LIB)
 foreach(LIB ${LIST_FAKEINTEL})
-    foreach(SOEXT ${LIST_FAKEINTEL_SOEXT})
-        add_library(${LIB}.${SOEXT} SHARED ${SOURCE_WI4MPI_EMPTY})
-    endforeach(SOEXT)
+    foreach(MAJOR ${LIST_FAKEINTEL_MAJOR})
+        add_library(${LIB}${MAJOR} SHARED ${SOURCE_WI4MPI_EMPTY})
+        set_target_properties(${LIB}${MAJOR} PROPERTIES OUTPUT_NAME ${LIB} SOVERSION ${MAJOR})
+    endforeach(MAJOR)
 endforeach(LIB)
 foreach(LIB ${LIST_FAKEOMPI})
-    foreach(SOEXT ${LIST_FAKEOMPI_SOEXT})
-        add_library(${LIB}.${SOEXT} SHARED ${SOURCE_WI4MPI_EMPTY})
-    endforeach(SOEXT)
+    foreach(MAJOR ${LIST_FAKEOMPI_MAJOR})
+        add_library(${LIB}${MAJOR} SHARED ${SOURCE_WI4MPI_EMPTY})
+        set_target_properties(${LIB}${MAJOR} PROPERTIES OUTPUT_NAME ${LIB} SOVERSION ${MAJOR})
+    endforeach(MAJOR)
 endforeach(LIB)
 
 #Headers
@@ -639,19 +642,19 @@ set_target_properties(wi4mpi_OMPI_OMPI
 endif()
 
 foreach(LIB ${LIST_FAKECXX})
-    foreach(SOEXT ${LIST_FAKECXX_SOEXT})
-        set_target_properties(${LIB}.${SOEXT} PROPERTIES COMPILE_FLAGS "-shared -fPIC")
-    endforeach(SOEXT)
+    foreach(MAJOR ${LIST_FAKECXX_MAJOR})
+        set_target_properties(${LIB}${MAJOR} PROPERTIES COMPILE_FLAGS "-shared -fPIC")
+    endforeach(MAJOR)
 endforeach(LIB)
 foreach(LIB ${LIST_FAKEINTEL})
-    foreach(SOEXT ${LIST_FAKEINTEL_SOEXT})
-        set_target_properties(${LIB}.${SOEXT} PROPERTIES COMPILE_FLAGS "-shared -fPIC")
-    endforeach(SOEXT)
+    foreach(MAJOR ${LIST_FAKEINTEL_MAJOR})
+        set_target_properties(${LIB}${MAJOR} PROPERTIES COMPILE_FLAGS "-shared -fPIC")
+    endforeach(MAJOR)
 endforeach(LIB)
 foreach(LIB ${LIST_FAKEOMPI})
-    foreach(SOEXT ${LIST_FAKEOMPI_SOEXT})
-        set_target_properties(${LIB}.${SOEXT} PROPERTIES COMPILE_FLAGS "-shared -fPIC")
-    endforeach(SOEXT)
+    foreach(MAJOR ${LIST_FAKEOMPI_MAJOR})
+        set_target_properties(${LIB}${MAJOR} PROPERTIES COMPILE_FLAGS "-shared -fPIC")
+    endforeach(MAJOR)
 endforeach(LIB)
 
 # Link options
@@ -788,36 +791,45 @@ install(TARGETS
 )
 
 foreach(LIB ${LIST_FAKECXX})
-    foreach(SOEXT ${LIST_FAKECXX_SOEXT})
-        install(FILES ${CMAKE_BINARY_DIR}/src/lib${LIB}.${SOEXT}.so DESTINATION libexec/wi4mpi/fakelibCXX
-                RENAME lib${LIB}.${SOEXT}
-                PERMISSIONS WORLD_READ WORLD_EXECUTE OWNER_READ OWNER_EXECUTE OWNER_WRITE GROUP_WRITE GROUP_READ GROUP_EXECUTE
-                )
-    endforeach(SOEXT)
+    foreach(MAJOR ${LIST_FAKECXX_MAJOR})
+        install(FILES ${CMAKE_BINARY_DIR}/src/lib${LIB}.so.${MAJOR}
+            DESTINATION libexec/wi4mpi/fakelibCXX
+            RENAME lib${LIB}.so.${MAJOR}
+            PERMISSIONS WORLD_READ WORLD_EXECUTE
+                OWNER_READ OWNER_EXECUTE OWNER_WRITE
+                GROUP_WRITE GROUP_READ GROUP_EXECUTE
+        )
+    endforeach(MAJOR)
 endforeach(LIB)
 foreach(LIB ${LIST_FAKEINTEL})
-    foreach(SOEXT ${LIST_FAKEINTEL_SOEXT})
-        install(FILES ${CMAKE_BINARY_DIR}/src/lib${LIB}.${SOEXT}.so DESTINATION libexec/wi4mpi/fakelibINTEL
-                RENAME lib${LIB}.${SOEXT}
-                PERMISSIONS WORLD_READ WORLD_EXECUTE OWNER_READ OWNER_EXECUTE OWNER_WRITE GROUP_WRITE GROUP_READ GROUP_EXECUTE
-                )
-    endforeach(SOEXT)
+    foreach(MAJOR ${LIST_FAKEINTEL_MAJOR})
+        install(FILES ${CMAKE_BINARY_DIR}/src/lib${LIB}.so.${MAJOR}
+            DESTINATION libexec/wi4mpi/fakelibINTEL
+            RENAME lib${LIB}.so.${MAJOR}
+            PERMISSIONS WORLD_READ WORLD_EXECUTE
+                OWNER_READ OWNER_EXECUTE OWNER_WRITE
+                GROUP_WRITE GROUP_READ GROUP_EXECUTE
+        )
+    endforeach(MAJOR)
 endforeach(LIB)
 foreach(LIB ${LIST_FAKEINTEL})
-    foreach(SOEXT ${LIST_FAKEINTEL_SOEXT})
-        install(FILES ${CMAKE_BINARY_DIR}/src/lib${LIB}.${SOEXT}.so DESTINATION libexec/wi4mpi/fakelibMPICH
-                RENAME lib${LIB}.${SOEXT}
-                PERMISSIONS WORLD_READ WORLD_EXECUTE OWNER_READ OWNER_EXECUTE OWNER_WRITE GROUP_WRITE GROUP_READ GROUP_EXECUTE
-                )
-    endforeach(SOEXT)
+    foreach(MAJOR ${LIST_FAKEINTEL_MAJOR})
+        install(FILES ${CMAKE_BINARY_DIR}/src/lib${LIB}.so.${MAJOR}
+            DESTINATION libexec/wi4mpi/fakelibMPICH
+            RENAME lib${LIB}.so.${MAJOR}
+            PERMISSIONS WORLD_READ WORLD_EXECUTE
+                OWNER_READ OWNER_EXECUTE OWNER_WRITE
+                GROUP_WRITE GROUP_READ GROUP_EXECUTE
+        )
+    endforeach(MAJOR)
 endforeach(LIB)
 foreach(LIB ${LIST_FAKEOMPI})
-    foreach(SOEXT ${LIST_FAKEOMPI_SOEXT})
-        install(FILES ${CMAKE_BINARY_DIR}/src/lib${LIB}.${SOEXT}.so DESTINATION libexec/wi4mpi/fakelibOMPI
-                RENAME lib${LIB}.${SOEXT}
+    foreach(MAJOR ${LIST_FAKEOMPI_MAJOR})
+        install(FILES ${CMAKE_BINARY_DIR}/src/lib${LIB}.so.${MAJOR} DESTINATION libexec/wi4mpi/fakelibOMPI
+            RENAME lib${LIB}.so.${MAJOR}
                 PERMISSIONS WORLD_READ WORLD_EXECUTE OWNER_READ OWNER_EXECUTE OWNER_WRITE GROUP_WRITE GROUP_READ GROUP_EXECUTE
                 )
-    endforeach(SOEXT)
+        endforeach(MAJOR)
 endforeach(LIB)
 
 #Interface libraries


### PR DESCRIPTION
Hey everyone ! We have been using WI4MPI recently, and came accross a problem when using libraries with an `RPATH`.

To circumvent the `RPATH`s total ignorance of `LD_LIBRARY_PATH`, we have been preloading necessary libraries.
Despite preloading the corresponding fake library (in `$WI4MPI/libexec/wi4mpi/fakelib*`) , the dynamic linker would still load the original library, leading to crashes. This behaviour was unexpected, as a preloaded library is expected not to be reopened.

This is due to a mismatch in the `SONAME` field of the `ELF` header. On a library installed with WI4MPI v3.4.1:
```
$ readelf -d /packages/wi4mpi/v3.4.1/libexec/wi4mpi/fakelibMPICH/libmpifort.so.12 | grep -i soname
 0x000000000000000e (SONAME)             Library soname: [libmpifort.so.12.so]
```

This is due to a CMake quirk that when asked to create a shared object, a system-specific suffix is appended. On linux, that is the outstanding `.so`.

The following PR uses CMake target properties to fix this. As the version is now a property, and CMake requires every target name to be unique, the `add_library` call now uses a composite name `${LIB}${MAJOR}`.
```cmake
foreach(LIB ${LIST_FAKECXX})
    foreach(MAJOR ${LIST_FAKECXX_MAJOR})
        add_library(${LIB}${MAJOR} SHARED ${SOURCE_WI4MPI_EMPTY})
        set_target_properties(${LIB}${MAJOR} PROPERTIES OUTPUT_NAME ${LIB} SOVERSION ${MAJOR})
    endforeach(MAJOR)
```
CMake will then output a library with the following format: `${OUTPUT_NAME}.so.${SOVERSION}`.

I changed the name of the affected variables and reformatted the modified lines. Please let me know if I can change anything for the sake of consistency within the project.