### PR TITLE
Several fixes to CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,19 +127,16 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fcommon")
 find_package(MPI REQUIRED) 
 if(MPI_C_FOUND AND MPI_Fortran_FOUND) #Need to be OpenMPI
   if(NOT DEFINED OPENMPI_ROOT)
-    execute_process(COMMAND "${MPI_C_COMPILER}" -show
+    execute_process(COMMAND "${MPI_C_COMPILER}" --showme:version
                     OUTPUT_VARIABLE ERR_VAR1
-                    OUTPUT_FILE "compiler_out"
+                    OUTPUT_FILE "compiler_version"
                     ERROR_QUIET)
-    execute_process(COMMAND "grep" openmpi
-                    INPUT_FILE "compiler_out"
+    execute_process(COMMAND "grep" -i "Open MPI"
+                    INPUT_FILE "compiler_version"
                     OUTPUT_VARIABLE ERR_VAR2
                     RESULT_VARIABLE COMMAND_RESULT1
                     ERROR_QUIET)
-    #execute_process(COMMAND "${MPI_C_COMPILER}" -show
-    #                COMMAND "grep" -io openmpi
-    #                 RESULT_VARIABLE RV)
-    #message(STATUS "res command : ${ERR_VAR2}")
+    message(STATUS "res command : ${ERR_VAR2}")
     if(NOT ERR_VAR2)
       message(FATAL_ERROR "Be sure to have an OpenMPI librarie in your PATH or set -DOPENMPI_ROOT=...")
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,9 @@ project(wi4mpi)
 if(POLICY CMP0054)
     cmake_policy(SET CMP0054 NEW)
 endif()
+if(POLICY CMP0057)
+    CMAKE_POLICY(SET CMP0057 NEW)
+endif()
 
 set(VERSION_MAJOR 3)
 set(VERSION_MINOR 5)
@@ -118,6 +121,14 @@ elseif(WI4MPI_REALEASE MATCHES GCC_JIT)
 else()
    set(WI4MPI_FLAGS ${CMAKE_C_FLAGS_NORMAL})
 endif()
+
+#if supported, use -Wl,--allow-multiple-definition
+INCLUDE(CheckLinkerFlag)
+CHECK_LINKER_FLAG( C "-Wl,--allow-multiple-definition" LINKER_SUPPORTS_ALLOW_MULTIPLE_DEFINITION )
+if(LINKER_SUPPORTS_ALLOW_MULTIPLE_DEFINITION)
+    set(CMAKE_SHARED_LINKER_FLAGS "-Wl,--allow-multiple-definition")
+endif()
+    
 
 find_package(MPI REQUIRED) 
 if(MPI_C_FOUND AND MPI_Fortran_FOUND) #Need to be OpenMPI

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,17 +122,7 @@ else()
    set(WI4MPI_FLAGS ${CMAKE_C_FLAGS_NORMAL})
 endif()
 
-#if supported, use -Wl,--allow-multiple-definition
-if (${CMAKE_VERSION} VERSION_LESS "3.18.0") # if support check is not supported, just use flags and cross fingers
-  set(CMAKE_SHARED_LINKER_FLAGS "-Wl,--allow-multiple-definition")
-else ()
-  INCLUDE(CheckLinkerFlag)
-  CHECK_LINKER_FLAG( C "-Wl,--allow-multiple-definition" LINKER_SUPPORTS_ALLOW_MULTIPLE_DEFINITION )
-  if(LINKER_SUPPORTS_ALLOW_MULTIPLE_DEFINITION)
-    set(CMAKE_SHARED_LINKER_FLAGS "-Wl,--allow-multiple-definition")
-  endif()
-endif()
-    
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fcommon")
 
 find_package(MPI REQUIRED) 
 if(MPI_C_FOUND AND MPI_Fortran_FOUND) #Need to be OpenMPI

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.0)
+cmake_minimum_required(VERSION 3.0.0)
 project(wi4mpi)
 
 if(POLICY CMP0054)
@@ -123,10 +123,14 @@ else()
 endif()
 
 #if supported, use -Wl,--allow-multiple-definition
-INCLUDE(CheckLinkerFlag)
-CHECK_LINKER_FLAG( C "-Wl,--allow-multiple-definition" LINKER_SUPPORTS_ALLOW_MULTIPLE_DEFINITION )
-if(LINKER_SUPPORTS_ALLOW_MULTIPLE_DEFINITION)
+if (${CMAKE_VERSION} VERSION_LESS "3.18.0") # if support check is not supported, just use flags and cross fingers
+  set(CMAKE_SHARED_LINKER_FLAGS "-Wl,--allow-multiple-definition")
+else ()
+  INCLUDE(CheckLinkerFlag)
+  CHECK_LINKER_FLAG( C "-Wl,--allow-multiple-definition" LINKER_SUPPORTS_ALLOW_MULTIPLE_DEFINITION )
+  if(LINKER_SUPPORTS_ALLOW_MULTIPLE_DEFINITION)
     set(CMAKE_SHARED_LINKER_FLAGS "-Wl,--allow-multiple-definition")
+  endif()
 endif()
     
 
@@ -149,7 +153,12 @@ if(MPI_C_FOUND AND MPI_Fortran_FOUND) #Need to be OpenMPI
     if(NOT ERR_VAR2)
       message(FATAL_ERROR "Be sure to have an OpenMPI librarie in your PATH or set -DOPENMPI_ROOT=...")
     endif()
-        get_filename_component(OPENMPI_ROOT ${MPI_C_INCLUDE_PATH} DIRECTORY)
+    foreach(p ${MPI_C_INCLUDE_PATH})
+      get_filename_component(OPENMPI_ROOT_TEST ${p} DIRECTORY)
+      if(EXISTS "${OPENMPI_ROOT_TEST}/lib")
+        set(OPENMPI_ROOT ${OPENMPI_ROOT_TEST})
+      endif ()
+    endforeach(p) 
   endif()
 endif()
 

--- a/Testing/compile/CMakeLists.txt
+++ b/Testing/compile/CMakeLists.txt
@@ -1,5 +1,5 @@
 project (compile)
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.0.0)
 
 # Copy source files
 set (LIST_FILES mpi_init.c mpi_init.cpp mpi_init.f mpi_init.f90)

--- a/Testing/mpi_init/CMakeLists.txt
+++ b/Testing/mpi_init/CMakeLists.txt
@@ -1,5 +1,5 @@
 project (mpi_init)
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.0.0)
 
 # Copy source files
 set (LIST_FILES mpi_init.c mpi_init.cpp mpi_init.f mpi_init.f90)

--- a/Testing/mpiio/CMakeLists.txt
+++ b/Testing/mpiio/CMakeLists.txt
@@ -1,5 +1,5 @@
 project (mpiio)
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.0.0)
 
 # Add tests
 file (COPY ${CMAKE_CURRENT_SOURCE_DIR}/run_mpi_file_open_tests.sh

--- a/Testing/mpirun/CMakeLists.txt
+++ b/Testing/mpirun/CMakeLists.txt
@@ -1,5 +1,5 @@
 project (mpirun)
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.0.0)
 
 # Add tests
 file (COPY ${CMAKE_CURRENT_SOURCE_DIR}/run_mpirun_tests.sh

--- a/Testing/timeout/CMakeLists.txt
+++ b/Testing/timeout/CMakeLists.txt
@@ -1,5 +1,5 @@
 project (timeout)
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.0.0)
 
 file (COPY ${CMAKE_CURRENT_SOURCE_DIR}/timeout_slow_add.c
         DESTINATION ${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
Use "-Wl,--allow-multiple-definition" if compiler supports it (fixing issue 10)
First cehck that linker supports -Wl,--allow-multiple-definition before using unless cmake version does not support CHECK_LINKER_FLAG (since 3.18)
Fixed an issue occuring when MPI_C_INCLUDE_PATH has more than one directory
upgraded cmake_minimum_required to 3.0.0
