### PR TITLE
Check presence of CC/CXX/FC compilers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,23 @@ elseif(WI4MPI_COMPILER MATCHES FUJITSU)
     set(MPI_Fortran_COMPILER "mpifrt" CACHE STRING "" FORCE)
 endif()
 
+# Check presence of CC, CXX and FC compilers
+# If nothing is found, the result will be <VAR>-NOTFOUND
+find_program(CC_PATH "${CC}")
+if("${CC_PATH}" MATCHES "CC_PATH-NOTFOUND")
+    message(FATAL_ERROR "C compiler not found in PATH!
+    Current value of CC is: ${CC}")
+endif()
+find_program(CXX_PATH "${CXX}")
+if("${CXX_PATH}" MATCHES "CXX_PATH-NOTFOUND")
+    message(FATAL_ERROR "C++ compiler not found in PATH!
+    Current value of CXX is: ${CXX}")
+endif()
+find_program(FC_PATH "${FC}")
+if("${FC_PATH}" MATCHES "FC_PATH-NOTFOUND")
+    message(FATAL_ERROR "Fortran compiler not found in PATH!
+    Current value of FC is: ${FC}")
+endif()
 enable_language(C CXX Fortran)
 
 #Define the compiling option according to the choosen release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,8 +142,14 @@ endif()
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fcommon")
 
 find_package(Threads)
-if(NOT CMAKE_THREAD_LIBS_INIT)
-    message(FATAL_ERROR "Be sure to have Pthread available on you system")
+if(${CMAKE_VERSION} VERSION_LESS "3.17.0")
+    if(NOT CMAKE_THREAD_LIBS_INIT)
+        message(FATAL_ERROR "Be sure to have Pthread available on your system")
+    endif()
+else()
+    if(NOT Threads_FOUND)
+        message(FATAL_ERROR "Be sure to have Pthread available on your system")
+    endif()
 endif()
 
 #Setting wi4mpi.cfg


### PR DESCRIPTION
Since MPI requirement was removed, there is no mechanism to check the presence of compilers.

```
$ cmake -DWI4MPI_COMPILER=intel ..
[...]
-- Configuring done
-- Generating done
```

```
$ make
[...]
make: *** [all] Error 2
```

```
$ icc
icc: command not found
```

After this patch, configuration releases an error :

```
$ cmake -DWI4MPI_COMPILER=intel ..
[...]
CMake Error at CMakeLists.txt:116 (message):
  C compiler not found in PATH!

      Current value of CC is: 


-- Configuring incomplete, errors occurred!
[...]
```