### PR TITLE
Parallel build error fix

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -469,19 +469,28 @@ set(LIST_FAKECXX_MAJOR ${LIST_FAKEINTEL_MAJOR} ${LIST_FAKEOMPI_MAJOR})
 foreach(LIB ${LIST_FAKECXX})
     foreach(MAJOR ${LIST_FAKECXX_MAJOR})
         add_library(${LIB}${MAJOR} SHARED ${SOURCE_WI4MPI_EMPTY})
-        set_target_properties(${LIB}${MAJOR} PROPERTIES OUTPUT_NAME ${LIB} SOVERSION ${MAJOR})
+        set_target_properties(${LIB}${MAJOR} PROPERTIES
+            LIBRARY_OUTPUT_NAME ${LIB}
+            LIBRARY_OUTPUT_DIRECTORY MAJOR_${MAJOR}
+            SOVERSION ${MAJOR})
     endforeach(MAJOR)
 endforeach(LIB)
 foreach(LIB ${LIST_FAKEINTEL})
     foreach(MAJOR ${LIST_FAKEINTEL_MAJOR})
         add_library(${LIB}${MAJOR} SHARED ${SOURCE_WI4MPI_EMPTY})
-        set_target_properties(${LIB}${MAJOR} PROPERTIES OUTPUT_NAME ${LIB} SOVERSION ${MAJOR})
+        set_target_properties(${LIB}${MAJOR} PROPERTIES
+            LIBRARY_OUTPUT_NAME ${LIB}
+            LIBRARY_OUTPUT_DIRECTORY MAJOR_${MAJOR}
+            SOVERSION ${MAJOR})
     endforeach(MAJOR)
 endforeach(LIB)
 foreach(LIB ${LIST_FAKEOMPI})
     foreach(MAJOR ${LIST_FAKEOMPI_MAJOR})
         add_library(${LIB}${MAJOR} SHARED ${SOURCE_WI4MPI_EMPTY})
-        set_target_properties(${LIB}${MAJOR} PROPERTIES OUTPUT_NAME ${LIB} SOVERSION ${MAJOR})
+        set_target_properties(${LIB}${MAJOR} PROPERTIES
+            LIBRARY_OUTPUT_NAME ${LIB}
+            LIBRARY_OUTPUT_DIRECTORY MAJOR_${MAJOR}
+            SOVERSION ${MAJOR})
     endforeach(MAJOR)
 endforeach(LIB)
 
@@ -871,7 +880,7 @@ install(TARGETS
 
 foreach(LIB ${LIST_FAKECXX})
     foreach(MAJOR ${LIST_FAKECXX_MAJOR})
-        install(FILES ${CMAKE_BINARY_DIR}/src/lib${LIB}.so.${MAJOR}
+        install(FILES ${CMAKE_BINARY_DIR}/src/MAJOR_${MAJOR}/lib${LIB}.so.${MAJOR}
             DESTINATION libexec/wi4mpi/fakelibCXX
             RENAME lib${LIB}.so.${MAJOR}
             PERMISSIONS WORLD_READ WORLD_EXECUTE
@@ -882,7 +891,7 @@ foreach(LIB ${LIST_FAKECXX})
 endforeach(LIB)
 foreach(LIB ${LIST_FAKEINTEL})
     foreach(MAJOR ${LIST_FAKEINTEL_MAJOR})
-        install(FILES ${CMAKE_BINARY_DIR}/src/lib${LIB}.so.${MAJOR}
+        install(FILES ${CMAKE_BINARY_DIR}/src/MAJOR_${MAJOR}/lib${LIB}.so.${MAJOR}
             DESTINATION libexec/wi4mpi/fakelibINTEL
             RENAME lib${LIB}.so.${MAJOR}
             PERMISSIONS WORLD_READ WORLD_EXECUTE
@@ -893,7 +902,7 @@ foreach(LIB ${LIST_FAKEINTEL})
 endforeach(LIB)
 foreach(LIB ${LIST_FAKEINTEL})
     foreach(MAJOR ${LIST_FAKEINTEL_MAJOR})
-        install(FILES ${CMAKE_BINARY_DIR}/src/lib${LIB}.so.${MAJOR}
+        install(FILES ${CMAKE_BINARY_DIR}/src/MAJOR_${MAJOR}/lib${LIB}.so.${MAJOR}
             DESTINATION libexec/wi4mpi/fakelibMPICH
             RENAME lib${LIB}.so.${MAJOR}
             PERMISSIONS WORLD_READ WORLD_EXECUTE
@@ -904,11 +913,14 @@ foreach(LIB ${LIST_FAKEINTEL})
 endforeach(LIB)
 foreach(LIB ${LIST_FAKEOMPI})
     foreach(MAJOR ${LIST_FAKEOMPI_MAJOR})
-        install(FILES ${CMAKE_BINARY_DIR}/src/lib${LIB}.so.${MAJOR} DESTINATION libexec/wi4mpi/fakelibOMPI
+        install(FILES ${CMAKE_BINARY_DIR}/src/MAJOR_${MAJOR}/lib${LIB}.so.${MAJOR}
+            DESTINATION libexec/wi4mpi/fakelibOMPI
             RENAME lib${LIB}.so.${MAJOR}
-                PERMISSIONS WORLD_READ WORLD_EXECUTE OWNER_READ OWNER_EXECUTE OWNER_WRITE GROUP_WRITE GROUP_READ GROUP_EXECUTE
-                )
-        endforeach(MAJOR)
+            PERMISSIONS WORLD_READ WORLD_EXECUTE
+                OWNER_READ OWNER_EXECUTE OWNER_WRITE
+                GROUP_WRITE GROUP_READ GROUP_EXECUTE
+        )
+    endforeach(MAJOR)
 endforeach(LIB)
 
 #Interface libraries


### PR DESCRIPTION
Hey everyone,

This pull request is meant to allow safe parallel building of the project.

### What happened

We encountered a few issues compiling Wi4MPI in the lab in a parallel environment. For a high number of jobs, compilation would systematically fail, but would succeed after retrying once or twice. The errors would look like such:
```
cmake --build . --parallel 96
[...]
CMake Error: failed to create symbolic link 'libmpi_mpifh.so': file already exists
CMake Error: cmake_symlink_library: System Error: File exists
CMake Error: failed to create symbolic link 'libmpicxx.so': file already exists
CMake Error: cmake_symlink_library: System Error: File exists
[...]
gmake: *** [Makefile:146: all] Error 2
```

### Why it happened

Turns out CMake is having a hard time dealing with the multiple fake libraries built by Wi4MPI. Setting the `SOVERSION` flag in `set_target_properties` will trigger the creation of 'helper' symlinks to allow ease of access to the library.

https://github.com/cea-hpc/wi4mpi/blob/60bee2a51659a922aae6d0f101dd8a7261cc6fb2/src/CMakeLists.txt#L469-L474

From https://cmake.org/cmake/help/latest/prop_tgt/SOVERSION.html:

> For shared libraries [VERSION](https://cmake.org/cmake/help/latest/prop_tgt/VERSION.html#prop_tgt:VERSION) and SOVERSION can be used to specify the build version and API version respectively. When building or installing appropriate symlinks are created if the platform supports symlinks and the linker supports so-names

The created symlinks omit the major:
```
lrwxrwxrwx.  1 jskutnik prl_collab   15 Sep 21 10:42 libmpi_cxx.so -> libmpi_cxx.so.5
-rwxr-xr-x.  1 jskutnik prl_collab 7.8K Sep 21 10:42 libmpi_cxx.so.5
```

For single version library creations, that is fine, but for this specific use case, the symlinks conflict with each other, as multiple links with the same name will be created at the same time.

### What this changes

I introduced the `SOVERSION` flag into the project, as it influences the ELF header of the resulting files by setting the version number in it. One may remove it to make this go away, but this will result in inaccurate ELF headers.

This pull request introduces build directories based on the version number, using the `LIBRARY_OUTPUT_DIRECTORY` target property. The install directive then reflects this path change, but installs the file at the same location as usual.

```cmake
set_target_properties(${LIB}${MAJOR} PROPERTIES
            LIBRARY_OUTPUT_NAME ${LIB}
            LIBRARY_OUTPUT_DIRECTORY MAJOR_${MAJOR}
            SOVERSION ${MAJOR})
```

```cmake
install(FILES ${CMAKE_BINARY_DIR}/src/MAJOR_${MAJOR}/lib${LIB}.so.${MAJOR}
            DESTINATION libexec/wi4mpi/fakelibCXX
            RENAME lib${LIB}.so.${MAJOR}
            PERMISSIONS WORLD_READ WORLD_EXECUTE
                OWNER_READ OWNER_EXECUTE OWNER_WRITE
                GROUP_WRITE GROUP_READ GROUP_EXECUTE
        )
```