### PR TITLE
[fix](src/CMakeLists.txt): add mpiexec to install step

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -980,6 +980,7 @@ install(FILES
         interface/interface_utils/bin/mpifort
         interface/interface_utils/bin/mpif77
         interface/interface_utils/bin/mpif90
+        interface/interface_utils/bin/mpiexec
         interface/interface_utils/bin/mpirun DESTINATION bin
         PERMISSIONS WORLD_READ WORLD_EXECUTE OWNER_READ OWNER_EXECUTE OWNER_WRITE GROUP_WRITE GROUP_READ GROUP_EXECUTE
 )


### PR DESCRIPTION
Resolves https://github.com/cea-hpc/wi4mpi/issues/26
`mpiexec` already exists but was missing from CMAKE install step.