### PR TITLE
[fix](mpicc): do not link to libmpi.so if not needed

### DIFF
--- a/src/interface/interface_utils/bin/mpicc
+++ b/src/interface/interface_utils/bin/mpicc
@@ -29,7 +29,12 @@ progname=$(basename $0)
 WI4MPI_CFLAGS="-I${WI4MPI_ROOT}/include"
 WI4MPI_CXXFLAGS="-I${WI4MPI_ROOT}/include"
 WI4MPI_FCFLAGS="-I${WI4MPI_ROOT}/include -cpp"
-WI4MPI_LDFLAGS="-L${WI4MPI_ROOT}/lib -lmpi"
+
+## LD_FLAGS - LD Hack - required for "./configure" simple C program ##
+# The ld "--as-needed -lmpi" only link libmpi.so if really needed.
+# "--push-state" and "--pop-state" is a trick to anly apply "--as-needed" to "-lmpi" option.
+# and not affect other libs.
+WI4MPI_LDFLAGS="-L${WI4MPI_ROOT}/lib -Wl,--push-state,--as-needed -lmpi -Wl,--pop-state"
 
 case $progname in
     mpicc)


### PR DESCRIPTION
Allow configure application to compile a simple C code without any target (TO) MPI implementation.

Very important for Interface Mode.

Resolves issue #45.