### PR TITLE
Fix rank mapping

### DIFF
--- a/generator/C/functions.json
+++ b/generator/C/functions.json
@@ -3876,7 +3876,7 @@
         "var": "rank_dest", 
         "arg_dep": "", 
         "In": 0, 
-        "name": "int_ptr_mapper", 
+        "name": "dest_ptr_converter", 
         "Out": 1
       }
     ], 

--- a/generator/C/functions.json
+++ b/generator/C/functions.json
@@ -4668,7 +4668,7 @@
         "var": "target_count", 
         "arg_dep": "", 
         "In": 1, 
-        "name": "source_converter", 
+        "name": "int_mapper", 
         "Out": 0
       }, 
       {

--- a/generator/C/functions.json
+++ b/generator/C/functions.json
@@ -13128,7 +13128,7 @@
         "var": "ranks1[]", 
         "arg_dep": "n", 
         "In": 1, 
-        "name": "const_int_converter", 
+        "name": "source_converter", 
         "Out": 0
       }, 
       {
@@ -13142,7 +13142,7 @@
         "var": "ranks2[]", 
         "arg_dep": "n", 
         "In": 0, 
-        "name": "int_mapper", 
+        "name": "source_converter", 
         "Out": 1
       }
     ], 

--- a/generator/generator.py
+++ b/generator/generator.py
@@ -340,13 +340,17 @@ class generator:
                     str_test_out=arg['arg_dep']
                     if str_test_out == '*outcount':
                           str_test_out='incount'
+                    if 'MPI' in self.mappers[arg['name']]['type']:
+                        type_prefix = 'R_'
+                    else:
+                        type_prefix = ''
                     if len(str_test.split('*')) > 1:
-                       str='R_'+str_test.split('*')[0]+' *'+arg['var'].split('[')[0]+'_tmp = wi4mpi_alloc(sizeof(R_'+str_test.split('*')[0]+')*'+str_test_out+');'
+                       str=type_prefix+str_test.split('*')[0]+' *'+arg['var'].split('[')[0]+'_tmp = wi4mpi_alloc(sizeof('+type_prefix+str_test.split('*')[0]+')*'+str_test_out+');'
                     else:
                        if str_test == 'MPI_Status': #special case: where MPI_STATUSES_IGNORE is use as an argument for array_of_statuses in MPI_Waitall/Waitsome and MPI_Testall/Testsome
                           str='R_MPI_Status *array_of_statuses_tmp=(array_of_statuses==A_MPI_STATUSES_IGNORE?R_MPI_STATUSES_IGNORE:(R_MPI_Status *) wi4mpi_alloc(sizeof(R_'+self.mappers[arg['name']]['type']+')*'+str_test_out+'));'
                        else:
-                          str='R_'+str_test+' *'+arg['var'].split('[')[0]+'_tmp = wi4mpi_alloc(sizeof(R_'+self.mappers[arg['name']]['type']+')*'+str_test_out+');'
+                          str=type_prefix+str_test+' *'+arg['var'].split('[')[0]+'_tmp = wi4mpi_alloc(sizeof('+type_prefix+self.mappers[arg['name']]['type']+')*'+str_test_out+');'
               else:
                     str=self.add_prefix(self.mappers[arg['name']]['type'],prefix)+' '+arg['var']+'_tmp;'
         return str

--- a/src/interface/gen/mpi_translation_c.c
+++ b/src/interface/gen/mpi_translation_c.c
@@ -31515,12 +31515,22 @@ int A_MPI_Group_translate_ranks(A_MPI_Group group1, int n, int ranks1[],
   R_MPI_Group group1_tmp;
   group_conv_a2r(&group1, &group1_tmp);
 
+  int *ranks1_tmp = wi4mpi_alloc(sizeof(int) * n);
+  int i1;
+  for (i1 = 0; i1 < n; i1++) {
+    source_conv_a2r(&ranks1[i1], &ranks1_tmp[i1]);
+  }
   R_MPI_Group group2_tmp;
   group_conv_a2r(&group2, &group2_tmp);
-
-  int ret_tmp = LOCAL_MPI_Group_translate_ranks(group1_tmp, n, ranks1,
-                                                group2_tmp, ranks2);
-
+  int *ranks2_tmp = wi4mpi_alloc(sizeof(int) * n);
+  int ret_tmp = LOCAL_MPI_Group_translate_ranks(group1_tmp, n, ranks1_tmp,
+                                                group2_tmp, ranks2_tmp);
+  int i2;
+  for (i2 = 0; i2 < n; i2++) {
+    source_conv_r2a(&ranks2[i2], &ranks2_tmp[i2]);
+  }
+  wi4mpi_free(ranks1_tmp);
+  wi4mpi_free(ranks2_tmp);
   int ret = error_code_conv_r2a(ret_tmp);
   in_w = 0;
 #ifdef DEBUG

--- a/src/interface/gen/mpi_translation_c.c
+++ b/src/interface/gen/mpi_translation_c.c
@@ -12098,15 +12098,14 @@ int A_MPI_Get(void *origin_addr, int origin_count,
   source_conv_a2r(&target_rank, &target_rank_tmp);
   R_MPI_Aint target_disp_tmp;
   target_disp_tmp = (R_MPI_Aint)target_disp;
-  int target_count_tmp;
-  source_conv_a2r(&target_count, &target_count_tmp);
+
   R_MPI_Datatype target_datatype_tmp;
   datatype_conv_a2r(&target_datatype, &target_datatype_tmp);
   R_MPI_Win win_tmp;
   win_conv_a2r(&win, &win_tmp);
   int ret_tmp = LOCAL_MPI_Get(
       origin_addr_tmp, origin_count, origin_datatype_tmp, target_rank_tmp,
-      target_disp_tmp, target_count_tmp, target_datatype_tmp, win_tmp);
+      target_disp_tmp, target_count, target_datatype_tmp, win_tmp);
   int ret = error_code_conv_r2a(ret_tmp);
   in_w = 0;
 #ifdef DEBUG

--- a/src/interface/gen/mpi_translation_c.c
+++ b/src/interface/gen/mpi_translation_c.c
@@ -9797,11 +9797,12 @@ int A_MPI_Cart_shift(A_MPI_Comm comm, int direction, int disp, int *rank_source,
 
   int rank_source_ltmp;
   int *rank_source_tmp = &rank_source_ltmp;
-
+  int rank_dest_ltmp;
+  int *rank_dest_tmp = &rank_dest_ltmp;
   int ret_tmp = LOCAL_MPI_Cart_shift(comm_tmp, direction, disp, rank_source_tmp,
-                                     rank_dest);
+                                     rank_dest_tmp);
   source_conv_r2a(rank_source, rank_source_tmp);
-
+  dest_conv_r2a(rank_dest, rank_dest_tmp);
   int ret = error_code_conv_r2a(ret_tmp);
   in_w = 0;
 #ifdef DEBUG

--- a/src/preload/gen/mpi_translation_c.c
+++ b/src/preload/gen/mpi_translation_c.c
@@ -12057,15 +12057,14 @@ int A_MPI_Get(void *origin_addr, int origin_count,
   source_conv_a2r(&target_rank, &target_rank_tmp);
   R_MPI_Aint target_disp_tmp;
   target_disp_tmp = (R_MPI_Aint)target_disp;
-  int target_count_tmp;
-  source_conv_a2r(&target_count, &target_count_tmp);
+
   R_MPI_Datatype target_datatype_tmp;
   datatype_conv_a2r(&target_datatype, &target_datatype_tmp);
   R_MPI_Win win_tmp;
   win_conv_a2r(&win, &win_tmp);
   int ret_tmp = LOCAL_MPI_Get(
       origin_addr_tmp, origin_count, origin_datatype_tmp, target_rank_tmp,
-      target_disp_tmp, target_count_tmp, target_datatype_tmp, win_tmp);
+      target_disp_tmp, target_count, target_datatype_tmp, win_tmp);
   int ret = error_code_conv_r2a(ret_tmp);
   in_w = 0;
 #ifdef DEBUG

--- a/src/preload/gen/mpi_translation_c.c
+++ b/src/preload/gen/mpi_translation_c.c
@@ -9737,11 +9737,12 @@ int A_MPI_Cart_shift(A_MPI_Comm comm, int direction, int disp, int *rank_source,
 
   int rank_source_ltmp;
   int *rank_source_tmp = &rank_source_ltmp;
-
+  int rank_dest_ltmp;
+  int *rank_dest_tmp = &rank_dest_ltmp;
   int ret_tmp = LOCAL_MPI_Cart_shift(comm_tmp, direction, disp, rank_source_tmp,
-                                     rank_dest);
+                                     rank_dest_tmp);
   source_conv_r2a(rank_source, rank_source_tmp);
-
+  dest_conv_r2a(rank_dest, rank_dest_tmp);
   int ret = error_code_conv_r2a(ret_tmp);
   in_w = 0;
 #ifdef DEBUG

--- a/src/preload/gen/mpi_translation_c.c
+++ b/src/preload/gen/mpi_translation_c.c
@@ -31753,12 +31753,22 @@ int A_MPI_Group_translate_ranks(A_MPI_Group group1, int n, int ranks1[],
   R_MPI_Group group1_tmp;
   group_conv_a2r(&group1, &group1_tmp);
 
+  int *ranks1_tmp = wi4mpi_alloc(sizeof(int) * n);
+  int i1;
+  for (i1 = 0; i1 < n; i1++) {
+    source_conv_a2r(&ranks1[i1], &ranks1_tmp[i1]);
+  }
   R_MPI_Group group2_tmp;
   group_conv_a2r(&group2, &group2_tmp);
-
-  int ret_tmp = LOCAL_MPI_Group_translate_ranks(group1_tmp, n, ranks1,
-                                                group2_tmp, ranks2);
-
+  int *ranks2_tmp = wi4mpi_alloc(sizeof(int) * n);
+  int ret_tmp = LOCAL_MPI_Group_translate_ranks(group1_tmp, n, ranks1_tmp,
+                                                group2_tmp, ranks2_tmp);
+  int i2;
+  for (i2 = 0; i2 < n; i2++) {
+    source_conv_r2a(&ranks2[i2], &ranks2_tmp[i2]);
+  }
+  wi4mpi_free(ranks1_tmp);
+  wi4mpi_free(ranks2_tmp);
   int ret = error_code_conv_r2a(ret_tmp);
   in_w = 0;
 #ifdef DEBUG


### PR DESCRIPTION
Fix the mapping used in some functions.
Change the generator to correctly generate loop when arg_dep is present and type is primitive.
This fixes #63 .