### PR TITLE
Change fake ompi mpi comm symbols size

### DIFF
--- a/generator/C/ompi_const_set.txt
+++ b/generator/C/ompi_const_set.txt
@@ -1,6 +1,6 @@
-char ompi_mpi_comm_null[1024];
-char ompi_mpi_comm_self[1024];
-char ompi_mpi_comm_world[1024];
+char ompi_mpi_comm_null[512];
+char ompi_mpi_comm_self[512];
+char ompi_mpi_comm_world[512];
 char ompi_mpi_2cplex[512];
 char ompi_mpi_2dblcplex[512];
 char ompi_mpi_2dblprec[512];

--- a/src/interface/gen/mpi_translation_c.c
+++ b/src/interface/gen/mpi_translation_c.c
@@ -140,9 +140,9 @@ int __svml_irem4;
 int __svml_irem8_l9;
 #endif
 #if defined(OMPI_INTEL) || defined(_INTEL) || defined(_MPC)
-char ompi_mpi_comm_null[1024];
-char ompi_mpi_comm_self[1024];
-char ompi_mpi_comm_world[1024];
+char ompi_mpi_comm_null[512];
+char ompi_mpi_comm_self[512];
+char ompi_mpi_comm_world[512];
 char ompi_mpi_2cplex[512];
 char ompi_mpi_2dblcplex[512];
 char ompi_mpi_2dblprec[512];

--- a/src/preload/gen/mpi_translation_c.c
+++ b/src/preload/gen/mpi_translation_c.c
@@ -28,9 +28,9 @@
 int WI4MPI_errhandler_key;
 void debug_printer(const char *, ...);
 #if defined(OMPI_INTEL) || defined(_INTEL) || defined(_MPC)
-char ompi_mpi_comm_null[1024];
-char ompi_mpi_comm_self[1024];
-char ompi_mpi_comm_world[1024];
+char ompi_mpi_comm_null[512];
+char ompi_mpi_comm_self[512];
+char ompi_mpi_comm_world[512];
 char ompi_mpi_2cplex[512];
 char ompi_mpi_2dblcplex[512];
 char ompi_mpi_2dblprec[512];


### PR DESCRIPTION
They changed over time. Since v3, they are 512 bytes long. This will prevent warning against relinking with soft compiled against openmpi v3 or later. Should be most of them by now.

fix #69 